### PR TITLE
Fix typo in config parser

### DIFF
--- a/src/bin/carbonadod.rs
+++ b/src/bin/carbonadod.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     // Debug
     #[cfg(debug_assertions)]
     {
-        let logger = Logger::try_with_str("debug, carbonado=debug")?
+        let logger = Logger::try_with_str("trace, carbonado_node=trace, carbonado=trace")?
             .adaptive_format_for_stderr(AdaptiveFormat::Detailed)
             .adaptive_format_for_stdout(AdaptiveFormat::Detailed)
             .set_palette("196;208;10;7;8".to_owned())

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -9,7 +9,7 @@ use log::{debug, info};
 use rand::thread_rng;
 use secp256k1::generate_keypair;
 
-const RUST_LOG: &str = "carbonad_node=trace,carbonado=trace,file=trace";
+const RUST_LOG: &str = "carbonado_node=trace,carbonado=trace,file=trace";
 
 #[tokio::test]
 async fn write_read() -> Result<()> {


### PR DESCRIPTION
This typo kept overwriting the volume paths with tmp directories.